### PR TITLE
Downgrade nikic/php-parser to fix undefined method PhpParser\ParserFactory::create()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "ext-json": "*",
         "composer/semver": "^3.3",
         "guzzlehttp/guzzle": "^7.5",
+        "nikic/php-parser": "^4.0.0",
         "spryker-sdk/security-checker": "^0.2.0",
         "spryker-sdk/utils": "^0.2.1",
         "symfony/console": "^6.0",


### PR DESCRIPTION
I had issues getting the evaluator to run because the factory was rebuilt in nikic/php-parser:5.0.0 leading to the following error:

```
❯ php bin/console


 [WARNING] Some commands could not be registered:


In PhpParser.php line 29:

  Call to undefined method PhpParser\ParserFactory::create()
```

This merge request downgrades to the latest 4.x.x version available (currenty 4.18.0)

It might be a better way to make the evaluator compatible with version 5 of the php-parser. For a workaround locally, this works perfectly fine.