### PR TITLE
FRW-10648 Dropped PHP 8.2 Support.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
       fail-fast: false
       matrix:
         php-version: [
-            '8.2',
-            '8.3'
+            '8.3',
+            '8.4'
         ]
 
     steps:

--- a/.github/workflows/trigger-remote-pr.yml
+++ b/.github/workflows/trigger-remote-pr.yml
@@ -22,7 +22,7 @@ jobs:
             - name: "Install PHP"
               uses: shivammathur/setup-php@2.33.0
               with:
-                  php-version: 8.2
+                  php-version: 8.3
                   tools: composer:v2
 
             - run: |

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.3",
         "ext-ctype": "*",
         "ext-iconv": "*",
         "ext-json": "*",

--- a/src/Checker/PhpVersionChecker/CheckerStrategy/DeployYamlFilesPhpVersionStrategy.php
+++ b/src/Checker/PhpVersionChecker/CheckerStrategy/DeployYamlFilesPhpVersionStrategy.php
@@ -23,7 +23,7 @@ class DeployYamlFilesPhpVersionStrategy implements PhpVersionCheckerStrategyInte
     /**
      * @var string
      */
-    public const MESSAGE_USED_NOT_ALLOWED_PHP_VERSION = "Deploy file uses not allowed PHP image version \"%s\"\nImage tag must contain allowed PHP version (image:abc-8.2)";
+    public const MESSAGE_USED_NOT_ALLOWED_PHP_VERSION = "Deploy file uses not allowed PHP image version \"%s\"\nImage tag must contain allowed PHP version (image:abc-8.3)";
 
     /**
      * @var \SprykerSdk\Evaluator\Checker\PhpVersionChecker\CheckerStrategy\FileReader\DeploymentYamlFileReader

--- a/tests/Acceptance/Checker/PhpVersionCheckerTest.php
+++ b/tests/Acceptance/Checker/PhpVersionCheckerTest.php
@@ -28,7 +28,7 @@ class PhpVersionCheckerTest extends ApplicationTestCase
      */
     public function testReturnSuccessOnValidProject(): void
     {
-        $commandTester = $this->createCommandTester(TestHelper::VALID_PROJECT_PATH, ['PROJECT_PHP_VERSION' => '8.1']);
+        $commandTester = $this->createCommandTester(TestHelper::VALID_PROJECT_PATH, ['PROJECT_PHP_VERSION' => '8.2']);
         $commandTester->execute(['--checkers' => PhpVersionChecker::NAME]);
 
         $commandTester->assertCommandIsSuccessful();
@@ -58,10 +58,10 @@ class PhpVersionCheckerTest extends ApplicationTestCase
         | 2 | Composer json PHP constraint ">=9.2" does not match allowed php versions    | tests/Acceptance/_data/InvalidProject/composer.json    |
         +---+-----------------------------------------------------------------------------+--------------------------------------------------------+
         | 3 | Deploy file uses not allowed PHP image version "spryker/php:6.4-alpine3.12" | tests/Acceptance/_data/InvalidProject/deploy.dev.yml   |
-        |   | Image tag must contain allowed PHP version (image:abc-8.2)                  |                                                        |
+        |   | Image tag must contain allowed PHP version (image:abc-8.3)                  |                                                        |
         +---+-----------------------------------------------------------------------------+--------------------------------------------------------+
         | 4 | Deploy file uses not allowed PHP image version "spryker/php:6.2-alpine3.12" | tests/Acceptance/_data/InvalidProject/deploy.yml       |
-        |   | Image tag must contain allowed PHP version (image:abc-8.2)                  |                                                        |
+        |   | Image tag must contain allowed PHP version (image:abc-8.3)                  |                                                        |
         +---+-----------------------------------------------------------------------------+--------------------------------------------------------+
         | 5 | Not all the targets have same PHP versions                                  | Current php version $phpVersion: -                           |
         |   |                                                                             | tests/Acceptance/_data/InvalidProject/composer.json: - |

--- a/tests/Acceptance/ToolingSettings/IgnoreErrorsTest.php
+++ b/tests/Acceptance/ToolingSettings/IgnoreErrorsTest.php
@@ -61,7 +61,7 @@ class IgnoreErrorsTest extends ApplicationTestCase
         | 1 | Current PHP version "$phpVersion" is not allowed.                                 | Current php version $phpVersion                                  |
         +---+-----------------------------------------------------------------------------+------------------------------------------------------------+
         | 2 | Deploy file uses not allowed PHP image version "spryker/php:6.2-alpine3.12" | tests/Acceptance/_data/IgnoreErrorsCheckProject/deploy.yml |
-        |   | Image tag must contain allowed PHP version (image:abc-8.2)                  |                                                            |
+        |   | Image tag must contain allowed PHP version (image:abc-8.3)                  |                                                            |
         +---+-----------------------------------------------------------------------------+------------------------------------------------------------+
 
         Read more: https://docs.spryker.com/docs/scos/dev/guidelines/keeping-a-project-upgradable/upgradability-guidelines/php-version.html


### PR DESCRIPTION
- Developer(s): @olhalivitchuk  

- Ticket: https://spryker.atlassian.net/browse/FRW-10648

- Release Group: https://release.spryker.com/release-groups/view/6080

- merge: squash

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Evaluator             | patch (currently 0.x)          |                       |

-----------------------------------------

#### Module Evaluator

##### Change log

Improvements 

- Added `PHP 8.4` support.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
